### PR TITLE
Invite policy based on power level

### DIFF
--- a/corporal/policy/checker.go
+++ b/corporal/policy/checker.go
@@ -65,3 +65,19 @@ func (me *Checker) CanUserUseCustomDisplayName(policy Policy, userId string) boo
 func (me *Checker) CanUserUseCustomAvatar(policy Policy, userId string) bool {
 	return policy.Flags.AllowCustomUserAvatars
 }
+
+//Compares the power level of sender and invited members. Allows invite only within their power level and below.
+
+func (me *Checker) CanSendInvite(policy, userId, memberId)  bool {
+	memberPolicy := policy.GetUserPolicyByUserId(memberId)	
+	userPolicy := policy.GetUserPolicyByUserId(userId)	
+	if memberPolicy == nil {
+		return true
+	}
+
+	if userPolicy == nil {
+		return false
+	}
+
+	return memberPolicy.PowerLevel <= userPolicy.PowerLevel
+}

--- a/corporal/policy/policy.go
+++ b/corporal/policy/policy.go
@@ -58,4 +58,8 @@ type UserPolicy struct {
 
 	// Tells whether this user is forbidden from creating rooms.
 	ForbidRoomCreation *bool `json:"forbidRoomCreation"`
+
+	//PowerLevel.
+	PowerLevel int `json:"powerLevel"`
+
 }


### PR DESCRIPTION
## I should be able to restrict users to send invite to higher power level users.
- [X] Add new policy rule "PowerLevel"
- [X] Fetch invited users from Context
- [X] Compare their power level is equal or less.