### PR TITLE
Fix error message when HttpGateway.HttpApi is less than 0

### DIFF
--- a/corporal/configuration/configuration.go
+++ b/corporal/configuration/configuration.go
@@ -98,7 +98,7 @@ func validateConfiguration(configuration *Configuration) error {
 	}
 
 	if configuration.HttpApi.TimeoutMilliseconds <= 0 {
-		return fmt.Errorf("HttpGateway.HttpApi needs to be a positive number")
+		return fmt.Errorf("HttpApi.TimeoutMilliseconds needs to be a positive number")
 	}
 
 	return nil


### PR DESCRIPTION
This error message was very confusing until I looked at the code :sweat_smile: 