### PR TITLE
Fixed missing CORS header on Matrix error responses

### DIFF
--- a/config.json.dist
+++ b/config.json.dist
@@ -13,13 +13,13 @@
 	},
 
 	"HttpGateway": {
-		"ListenAddress": "127.0.0.1:41080",
+		"ListenAddress": "0.0.0.0:41080",
 		"TimeoutMilliseconds": 60000
 	},
 
 	"HttpApi": {
 		"Enabled": true,
-		"ListenAddress": "127.0.0.1:41081",
+		"ListenAddress": "0.0.0.0:41081",
 		"AuthorizationBearerToken": "UB42Gd0qUH6rkR4yxWbtTX85XCC9B0X1G7tFp64q9UlBjVdjZrtqaBIxFzj4dQvSiRYmxfF4hMAel6bw3xO7jnRgCGQBwBnjpPEfW1lrVAZFP3p55KxBra3mQDGrntE0",
 		"TimeoutMilliseconds": 15000
 	},

--- a/corporal/container/container.go
+++ b/corporal/container/container.go
@@ -108,6 +108,15 @@ func BuildContainer(
 		)
 	})
 
+	container.Set("httpgateway.interceptor.uiauth", func(c service.Container) interface{} {
+		return httpgateway.NewUiAuthInterceptor(
+			container.Get("policy.store").(*policy.Store),
+			configuration.Matrix.HomeserverDomainName,
+			container.Get("policy.userauth.checker").(*userauth.Checker),
+			container.Get("matrix.shared_secret_auth.password_generator").(*matrix.SharedSecretAuthPasswordGenerator),
+		)
+	})
+
 	container.Set("httpgateway.server", func(c service.Container) interface{} {
 		instance := httpgateway.NewServer(
 			logger,
@@ -117,6 +126,7 @@ func BuildContainer(
 			container.Get("policy.store").(*policy.Store),
 			container.Get("policy.checker").(*policy.Checker),
 			container.Get("httpgateway.interceptor.login").(httpgateway.Interceptor),
+			container.Get("httpgateway.interceptor.uiauth").(httpgateway.Interceptor),
 			time.Duration(configuration.HttpGateway.TimeoutMilliseconds)*time.Millisecond,
 		)
 

--- a/corporal/httpgateway/interceptor_ui.go
+++ b/corporal/httpgateway/interceptor_ui.go
@@ -1,0 +1,136 @@
+package httpgateway
+
+import (
+	"bytes"
+	"devture-matrix-corporal/corporal/httphelp"
+	"devture-matrix-corporal/corporal/matrix"
+	"devture-matrix-corporal/corporal/policy"
+	"devture-matrix-corporal/corporal/userauth"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+type UiAuthInterceptor struct {
+	policyStore                       *policy.Store
+	homeserverDomainName              string
+	userAuthChecker                   *userauth.Checker
+	sharedSecretAuthPasswordGenerator *matrix.SharedSecretAuthPasswordGenerator
+}
+
+func NewUiAuthInterceptor(
+	policyStore *policy.Store,
+	homeserverDomainName string,
+	userAuthChecker *userauth.Checker,
+	sharedSecretAuthPasswordGenerator *matrix.SharedSecretAuthPasswordGenerator,
+) *UiAuthInterceptor {
+	return &UiAuthInterceptor{
+		policyStore:                       policyStore,
+		homeserverDomainName:              homeserverDomainName,
+		userAuthChecker:                   userAuthChecker,
+		sharedSecretAuthPasswordGenerator: sharedSecretAuthPasswordGenerator,
+	}
+}
+
+func (me *UiAuthInterceptor) Intercept(r *http.Request) InterceptorResponse {
+	loggingContextFields := logrus.Fields{}
+
+	var payload map[string]interface{}
+
+	err := httphelp.GetJsonFromRequestBody(r, &payload)
+	if err != nil {
+		loggingContextFields["err"] = err.Error()
+		return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorBadJson, "Bad input")
+	}
+
+	// This all has to be done manually since UI auth can have custom data anywhere
+	if payload["auth"] != nil {
+		auth := payload["auth"].(map[string]interface{})
+		if auth["type"].(string) == "m.login.password" {
+			pass, pass_ok := auth["password"].(string)
+			if auth["identifier"] == nil || !pass_ok {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorBadJson, "Bad input")
+			}
+			ident := auth["identifier"].(map[string]interface{})
+			id_type, id_type_ok := ident["type"].(string)
+			user, user_ok := ident["user"].(string)
+			if !id_type_ok {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorBadJson, "Bad input")
+			}
+			// TODO: Support 3pids here
+			if id_type != "m.id.user" || !user_ok {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorUnknown, "Third party user IDs not yet supported")
+			}
+
+			loggingContextFields["userId"] = user
+
+			userIdFull, err := matrix.DetermineFullUserId(user, me.homeserverDomainName)
+			if err != nil {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorForbidden, "Cannot interpret user id")
+			}
+
+			// Replace the logging field with a (potentially) better one
+			loggingContextFields["userId"] = userIdFull
+
+			if !matrix.IsFullUserIdOfDomain(userIdFull, me.homeserverDomainName) {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorForbidden, "Rejecting non-own domains")
+			}
+
+			policy := me.policyStore.Get()
+			if policy == nil {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorUnknown, "Missing policy")
+			}
+
+			userPolicy := policy.GetUserPolicyByUserId(userIdFull)
+			if userPolicy == nil {
+				// Not a user we manage.
+				// Let it go through and let the upstream server's policies apply, whatever they may be.
+				return InterceptorResponse{
+					Result:               InterceptorResultProxy,
+					LoggingContextFields: loggingContextFields,
+				}
+			}
+
+			if !userPolicy.Active {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorUserDeactivated, "Deactivated in policy")
+			}
+
+			loggingContextFields["authType"] = userPolicy.AuthType
+
+			isAuthenticated, err := me.userAuthChecker.Check(
+				userIdFull,
+				pass,
+				userPolicy.AuthType,
+				userPolicy.AuthCredential,
+			)
+			if err != nil {
+				loggingContextFields["err"] = err.Error()
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorUnknown, "Internal authenticator error")
+			}
+
+			if !isAuthenticated {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorForbidden, "Failed authentication")
+			}
+
+			// We don't need to do it, but let's ensure the payload uses the full user id.
+			ident["user"] = userIdFull
+			auth["identifier"] = ident
+			auth["password"] = me.sharedSecretAuthPasswordGenerator.GenerateForUserId(userIdFull)
+			payload["auth"] = auth
+
+			newBodyBytes, err := json.Marshal(payload)
+			if err != nil {
+				return createInterceptorErrorResponse(loggingContextFields, matrix.ErrorUnknown, "Internal error")
+			}
+
+			r.Body = ioutil.NopCloser(bytes.NewReader(newBodyBytes))
+			r.ContentLength = int64(len(newBodyBytes))
+		}
+	}
+	return InterceptorResponse{
+		Result:               InterceptorResultProxy,
+		LoggingContextFields: loggingContextFields,
+	}
+}

--- a/corporal/httpgateway/util.go
+++ b/corporal/httpgateway/util.go
@@ -10,7 +10,7 @@ import (
 )
 
 func respondWithMatrixError(w http.ResponseWriter, httpStatusCode int, errorCode string, errorMessage string) {
-    w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(httpStatusCode)
 
 	resp := gomatrix.RespError{

--- a/corporal/httpgateway/util.go
+++ b/corporal/httpgateway/util.go
@@ -10,6 +10,7 @@ import (
 )
 
 func respondWithMatrixError(w http.ResponseWriter, httpStatusCode int, errorCode string, errorMessage string) {
+    w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(httpStatusCode)
 
 	resp := gomatrix.RespError{

--- a/policy.json.dist
+++ b/policy.json.dist
@@ -1,4 +1,5 @@
 {
+	"schemaVersion": 1,
 	"flags": {
 		"allowCustomUserDisplayNames": false,
 		"allowCustomUserAvatars": false,


### PR DESCRIPTION
I noticed this when I mistyped my password and noticed the error `Problem communicating with the given homeserver` instead of the normal password error. This was because while the `OPTIONS` request returned an `Access-Control-Allow-Origin`, the Matrix error response to the `POST` request did not.

This also fixes some issues with the Docker setup process: One where the version was missing from the schema and one where the Corporal container only listened on `127.0.0.1`.