### PR TITLE
Fixed missing CORS header on Matrix error responses, take 2

### DIFF
--- a/corporal/httpgateway/util.go
+++ b/corporal/httpgateway/util.go
@@ -10,6 +10,7 @@ import (
 )
 
 func respondWithMatrixError(w http.ResponseWriter, httpStatusCode int, errorCode string, errorMessage string) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(httpStatusCode)
 
 	resp := gomatrix.RespError{

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,7 +12,7 @@ If you'd like to contribute code to this project or give it a try locally (befor
 
 - copy the sample configuration: `cp config.json.dist config.json`
 
-- change the `ListenAddress` from `127.0.0.1` to `0.0.0.0` in `config.json`
+- change the `ListenAddress` from `127.0.0.1` to `0.0.0.0` in `config.json`, as that's necessary for running matrix-corporal in a container (something we instruct you of doing below)
 
 - copy the sample policy: `cp policy.json.dist policy.json`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,6 +12,8 @@ If you'd like to contribute code to this project or give it a try locally (befor
 
 - copy the sample configuration: `cp config.json.dist config.json`
 
+- change the `ListenAddress` from `127.0.0.1` to `0.0.0.0` in `config.json`
+
 - copy the sample policy: `cp policy.json.dist policy.json`
 
 - build and run the `matrix-corporal` program by executing: `make run-in-container`

--- a/policy.json.dist
+++ b/policy.json.dist
@@ -1,4 +1,5 @@
 {
+	"schemaVersion": 1,
 	"flags": {
 		"allowCustomUserDisplayNames": false,
 		"allowCustomUserAvatars": false,


### PR DESCRIPTION
I really messed up the first PR, so I just completely re-did it. Hope this is a bit better ;)

I noticed this when I mistyped my password and noticed the error `Problem communicating with the given homeserver` instead of the normal password error. This was because while the `OPTIONS` request returned an `Access-Control-Allow-Origin`, the Matrix error response to the `POST` request did not.

This also fixes some issues with the development setup process: The version was added to the schema and an instruction was added to make the container listen on all of its IPs.