### PR TITLE
Add power levels handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ It's probably best explained with an example. Here's a [policy](docs/policy.md) 
 			"authCredential": "PaSSw0rD",
 			"displayName": "John",
 			"avatarUri": "https://example.com/john.jpg",
-			"joinedRoomIds": ["!roomA:example.com", "!roomB:example.com"]
+			"joinedRooms": [
+				{"roomId": "!roomA:example.com", "powerLevel": 0},
+				{"roomId": "!roomB:example.com", "powerLevel": 50}
+			]
 		},
 		{
 			"id": "@peter:example.com",
@@ -96,7 +99,9 @@ It's probably best explained with an example. Here's a [policy](docs/policy.md) 
 			"authCredential": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
 			"displayName": "Just Peter",
 			"avatarUri": "",
-			"joinedRoomIds": ["!roomB:example.com"]
+			"joinedRooms": [
+				{"roomId": "!roomB:example.com", "powerLevel": 0}
+			]
 		},
 		{
 			"id": "@george:example.com",
@@ -105,7 +110,10 @@ It's probably best explained with an example. Here's a [policy](docs/policy.md) 
 			"authCredential": "https://intranet.example.com/_matrix-internal/identity/v1/check_credentials",
 			"displayName": "Georgey",
 			"avatarUri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
-			"joinedRoomIds": ["!roomA:example.com", "!roomB:example.com"]
+			"joinedRooms": [
+				{"roomId": "!roomA:example.com", "powerLevel": 25},
+				{"roomId": "!roomB:example.com", "powerLevel": 50}
+			]
 		}
 	]
 }

--- a/corporal/connector/api.go
+++ b/corporal/connector/api.go
@@ -530,8 +530,6 @@ func (me *ApiConnector) LeaveRoom(
 		return err
 	}
 
-	//TODO remove user from power level
-
 	return matrix.ExecuteWithRateLimitRetries(me.logger, "room.leave", func() error {
 		// This request is idempotent.
 		_, err := client.LeaveRoom(roomId)

--- a/corporal/connector/interface.go
+++ b/corporal/connector/interface.go
@@ -21,7 +21,7 @@ type MatrixConnector interface {
 	SetUserAvatar(ctx *AccessTokenContext, userId string, avatar *avatar.Avatar) error
 
 	InviteUserToRoom(ctx *AccessTokenContext, inviterId string, inviteeId string, roomId string) error
-	UpdateRoomUserPowerLevel(ctx *AccessTokenContext, updaterId string, userId string, roomId string, powerLevel int) error
+	UpdateRoomUserPowerLevel(ctx *AccessTokenContext, updaterId string, roomPowerForUserId map[string]int, roomId string) error
 	JoinRoom(ctx *AccessTokenContext, userId string, roomId string) error
 	LeaveRoom(ctx *AccessTokenContext, userId string, roomId string) error
 }

--- a/corporal/connector/interface.go
+++ b/corporal/connector/interface.go
@@ -21,6 +21,7 @@ type MatrixConnector interface {
 	SetUserAvatar(ctx *AccessTokenContext, userId string, avatar *avatar.Avatar) error
 
 	InviteUserToRoom(ctx *AccessTokenContext, inviterId string, inviteeId string, roomId string) error
+	UpdateRoomUserPowerLevel(ctx *AccessTokenContext, updaterId string, userId string, roomId string, powerLevel int) error
 	JoinRoom(ctx *AccessTokenContext, userId string, roomId string) error
 	LeaveRoom(ctx *AccessTokenContext, userId string, roomId string) error
 }

--- a/corporal/connector/state.go
+++ b/corporal/connector/state.go
@@ -13,11 +13,16 @@ func (me *CurrentState) GetUserStateByUserId(userId string) *CurrentUserState {
 	return nil
 }
 
+type CurrentUserRoomState struct {
+	RoomId     string `json:"roomId"`
+	PowerLevel int    `json:"powerLevel"`
+}
+
 type CurrentUserState struct {
-	Id                  string   `json:"id"`
-	Active              bool     `json:"active"`
-	DisplayName         string   `json:"displayName"`
-	AvatarMxcUri        string   `json:"avatarMxcUri"`
-	AvatarSourceUriHash string   `json:"avatarSourceUriHash"`
-	JoinedRoomIds       []string `json:"joinedRoomIds"`
+	Id                  string                 `json:"id"`
+	Active              bool                   `json:"active"`
+	DisplayName         string                 `json:"displayName"`
+	AvatarMxcUri        string                 `json:"avatarMxcUri"`
+	AvatarSourceUriHash string                 `json:"avatarSourceUriHash"`
+	JoinedRoom          []CurrentUserRoomState `json:"joinedRoomIds"`
 }

--- a/corporal/connector/state.go
+++ b/corporal/connector/state.go
@@ -24,5 +24,5 @@ type CurrentUserState struct {
 	DisplayName         string                 `json:"displayName"`
 	AvatarMxcUri        string                 `json:"avatarMxcUri"`
 	AvatarSourceUriHash string                 `json:"avatarSourceUriHash"`
-	JoinedRoom          []CurrentUserRoomState `json:"joinedRoomIds"`
+	JoinedRooms         []CurrentUserRoomState `json:"joinedRooms"`
 }

--- a/corporal/policy/checker.go
+++ b/corporal/policy/checker.go
@@ -1,9 +1,5 @@
 package policy
 
-import (
-	"devture-matrix-corporal/corporal/util"
-)
-
 type Checker struct {
 }
 
@@ -68,8 +64,10 @@ func (me *Checker) CanUserChangeOwnMembershipStateInRoom(policy Policy, userId s
 		return true
 	}
 
-	if util.IsStringInArray(roomId, userPolicy.JoinedRoomIds) {
-		return false
+	for _, value := range userPolicy.JoinedRooms {
+		if value.RoomId == roomId {
+			return false
+		}
 	}
 
 	return true

--- a/corporal/policy/policy.go
+++ b/corporal/policy/policy.go
@@ -85,6 +85,11 @@ type PolicyFlags struct {
 	Allow3pidLogin bool `json:"allow3pidLogin"`
 }
 
+type RoomState struct {
+	RoomId     string `json:"roomId"`
+	PowerLevel int    `json:"powerLevel"`
+}
+
 type UserPolicy struct {
 	Id     string `json:"id"`
 	Active bool   `json:"active"`
@@ -104,7 +109,7 @@ type UserPolicy struct {
 	DisplayName string `json:"displayName"`
 	AvatarUri   string `json:"avatarUri"`
 
-	JoinedRoomIds []string `json:"joinedRoomIds"`
+	JoinedRooms []*RoomState `json:"joinedRooms"`
 
 	// ForbidRoomCreation tells whether this user is forbidden from creating rooms.
 	ForbidRoomCreation *bool `json:"forbidRoomCreation"`

--- a/corporal/policy/policy.go
+++ b/corporal/policy/policy.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Policy struct {
-	SchemaVerson int `json:"schemaVersion"`
+	SchemaVersion int `json:"schemaVersion"`
 
 	// IdentificationStamp holds a policy identification value.
 	// Policy providers/generators can attach any string value to a policy to help identify it.

--- a/corporal/policy/testdata/01-managed-user.json
+++ b/corporal/policy/testdata/01-managed-user.json
@@ -9,7 +9,12 @@
 			{
 				"id": "@a:host",
 				"active": true,
-				"joinedRoomIds": ["!a:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					}
+				]
 			}
 		]
 	},

--- a/corporal/policy/testdata/02-unmanaged-user.json
+++ b/corporal/policy/testdata/02-unmanaged-user.json
@@ -1,6 +1,6 @@
 {
 	"policy": {
-		"managedRoomIds": [
+		"managedRooms": [
 			"!a:host",
 			"!b:host"
 		],

--- a/corporal/policy/validator.go
+++ b/corporal/policy/validator.go
@@ -16,8 +16,8 @@ func NewValidator(homeserverDomainName string) *Validator {
 }
 
 func (me *Validator) Validate(policy *Policy) error {
-	if policy.SchemaVerson != 1 {
-		return fmt.Errorf("found policy with schema version (%d) that we do not support", policy.SchemaVerson)
+	if policy.SchemaVersion != 1 {
+		return fmt.Errorf("found policy with schema version (%d) that we do not support", policy.SchemaVersion)
 	}
 
 	for _, userId := range policy.GetManagedUserIds() {

--- a/corporal/policy/validator.go
+++ b/corporal/policy/validator.go
@@ -16,7 +16,7 @@ func NewValidator(homeserverDomainName string) *Validator {
 }
 
 func (me *Validator) Validate(policy *Policy) error {
-	if policy.SchemaVersion != 1 {
+	if policy.SchemaVersion != 2 {
 		return fmt.Errorf("found policy with schema version (%d) that we do not support", policy.SchemaVersion)
 	}
 

--- a/corporal/reconciliation/actions.go
+++ b/corporal/reconciliation/actions.go
@@ -9,7 +9,8 @@ const (
 	ActionUserActivate       = "user.activate"
 	ActionUserDeactivate     = "user.deactivate"
 
-	ActionRoomJoin          = "room.join"
-	ActionRoomLeave         = "room.leave"
-	ActionRoomSetPowerLevel = "room.power_level"
+	ActionRoomJoin                = "room.join"
+	ActionRoomLeave               = "room.leave"
+	ActionRoomUserSetPowerLevel   = "room.user_set_power_level"
+	ActionRoomUsersSetPowerLevels = "room.users_set_power_levels"
 )

--- a/corporal/reconciliation/actions.go
+++ b/corporal/reconciliation/actions.go
@@ -9,6 +9,7 @@ const (
 	ActionUserActivate       = "user.activate"
 	ActionUserDeactivate     = "user.deactivate"
 
-	ActionRoomJoin  = "room.join"
-	ActionRoomLeave = "room.leave"
+	ActionRoomJoin          = "room.join"
+	ActionRoomLeave         = "room.leave"
+	ActionRoomSetPowerLevel = "room.power_level"
 )

--- a/corporal/reconciliation/computator/computator.go
+++ b/corporal/reconciliation/computator/computator.go
@@ -30,6 +30,7 @@ func (me *ReconciliationStateComputator) Compute(
 		Actions: make([]*reconciliation.StateAction, 0),
 	}
 
+	computedActions := make([]*reconciliation.StateAction, 0)
 	for _, userPolicy := range policy.User {
 		userId := userPolicy.Id
 
@@ -42,8 +43,57 @@ func (me *ReconciliationStateComputator) Compute(
 			userPolicy,
 		)
 
-		reconciliationState.Actions = append(reconciliationState.Actions, actions...)
+		computedActions = append(computedActions, actions...)
 	}
+
+	// Group all set power actions for each room
+	groupedActions := make([]*reconciliation.StateAction, 0)
+
+	setPowerActionsByRoomId := make(map[string]*reconciliation.StateAction)
+
+	for _, action := range computedActions {
+		if action.Type != reconciliation.ActionRoomUserSetPowerLevel {
+			groupedActions = append(groupedActions, action)
+			continue
+		}
+
+		roomId, err := action.GetStringPayloadDataByKey("roomId")
+		if err != nil {
+			return nil, err
+		}
+
+		powerLevel, err := action.GetIntPayloadDataByKey("powerLevel")
+		if err != nil {
+			return nil, err
+		}
+
+		userId, err := action.GetStringPayloadDataByKey("userId")
+		if err != nil {
+			return nil, err
+		}
+
+		setPowerAction, exists := setPowerActionsByRoomId[roomId]
+		if !exists {
+			userPowerByRoom := make(map[string]int)
+			userPowerByRoom[userId] = powerLevel
+			newAction := &reconciliation.StateAction{
+				Type: reconciliation.ActionRoomUsersSetPowerLevels,
+				Payload: map[string]interface{}{
+					"roomPowerForUserId": userPowerByRoom,
+					"roomId":             roomId,
+				},
+			}
+			setPowerActionsByRoomId[roomId] = newAction
+		} else {
+			roomPowerPayload := setPowerAction.Payload["roomPowerForUserId"].(map[string]int)
+			roomPowerPayload[userId] = powerLevel
+		}
+	}
+
+	for _, action := range setPowerActionsByRoomId {
+		groupedActions = append(groupedActions, action)
+	}
+	reconciliationState.Actions = groupedActions
 
 	return reconciliationState, nil
 }
@@ -282,27 +332,39 @@ func (me *ReconciliationStateComputator) computeUserRoomChanges(
 
 		var currentRoomPowerFound *int = nil
 		if currentUserState != nil {
-			for _, currentRoom := range currentUserState.JoinedRoom {
+			for _, currentRoom := range currentUserState.JoinedRooms {
 				if currentRoom.RoomId == room.RoomId {
 					currentRoomPowerFound = &currentRoom.PowerLevel
+					break
 				}
 			}
 		}
 
-		// If the user is not a member of the room, join it
 		if currentRoomPowerFound == nil {
+			// If the user is not a member of the room, join it
 			actions = append(actions, &reconciliation.StateAction{
 				Type: reconciliation.ActionRoomJoin,
+				Payload: map[string]interface{}{
+					"userId": userId,
+					"roomId": room.RoomId,
+				},
+			})
+			actions = append(actions, &reconciliation.StateAction{
+				Type: reconciliation.ActionRoomUserSetPowerLevel,
 				Payload: map[string]interface{}{
 					"userId":     userId,
 					"roomId":     room.RoomId,
 					"powerLevel": room.PowerLevel,
 				},
 			})
-			// If the user is a member of the room but has a different power level, change it
+
 		} else if *currentRoomPowerFound != room.PowerLevel {
+			// If the user is a member of the room but has a different power level, change it
+
+			userPowerByRoom := make(map[string]int)
+			userPowerByRoom[userId] = room.PowerLevel
 			actions = append(actions, &reconciliation.StateAction{
-				Type: reconciliation.ActionRoomSetPowerLevel,
+				Type: reconciliation.ActionRoomUserSetPowerLevel,
 				Payload: map[string]interface{}{
 					"userId":     userId,
 					"roomId":     room.RoomId,
@@ -313,21 +375,21 @@ func (me *ReconciliationStateComputator) computeUserRoomChanges(
 	}
 
 	if currentUserState != nil {
-		for _, room := range currentUserState.JoinedRoom {
+		for _, room := range currentUserState.JoinedRooms {
 			if !util.IsStringInArray(room.RoomId, managedRoomIds) {
 				//We rightfully ignore rooms we don't care about.
 				continue
 			}
 
-			isInPolicyJoinedRoom := false
-			for _, room := range userPolicy.JoinedRooms {
-				if room.RoomId == room.RoomId {
-					isInPolicyJoinedRoom = true
+			isInPolicyJoinedRooms := false
+			for _, policyRoom := range userPolicy.JoinedRooms {
+				if room.RoomId == policyRoom.RoomId {
+					isInPolicyJoinedRooms = true
 					break
 				}
 			}
 
-			if isInPolicyJoinedRoom {
+			if isInPolicyJoinedRooms {
 				continue
 			}
 

--- a/corporal/reconciliation/computator/testdata/01-missing-user-is-created.json
+++ b/corporal/reconciliation/computator/testdata/01-missing-user-is-created.json
@@ -22,14 +22,19 @@
 				"authType": "plain",
 				"authCredential": "test",
 				"active": true,
-				"joinedRoomIds": ["!a:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					}
+				]
 			},
 			{
 				"id": "@b:host",
 				"authType": "sha1",
 				"authCredential": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -56,6 +61,14 @@
 				"payload": {
 					"userId": "@b:host",
 					"password": "__RANDOM__"
+				}
+			},
+
+			{
+				"type": "room.users_set_power_levels",
+				"payload": {
+					"roomId": "!a:host",
+					"roomPowerForUserId": "map[@a:host:0]"
 				}
 			}
 		]

--- a/corporal/reconciliation/computator/testdata/02-more-complicated.json
+++ b/corporal/reconciliation/computator/testdata/02-more-complicated.json
@@ -4,12 +4,31 @@
 			{
 				"id": "@a:host",
 				"active": true,
-				"joinedRoomIds": ["!a:host", "!b:host", "!c:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					},
+					{
+						"roomId": "!b:host",
+						"powerLevel": 0
+					},
+					{
+						"roomId": "!c:host",
+						"powerLevel": 0
+					}
+				]
+
 			},
 			{
 				"id": "@b:host",
 				"active": true,
-				"joinedRoomIds": ["!b:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!b:host",
+						"powerLevel": 0
+					}
+				]
 			}
 		]
 	},
@@ -31,22 +50,45 @@
 			{
 				"id": "@a:host",
 				"active": true,
-				"joinedRoomIds": ["!a:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"PowerLevel": 0
+					}
+				]
 			},
 			{
 				"id": "@b:host",
 				"active": true,
-				"joinedRoomIds": ["!a:host", "!b:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					},
+					{
+						"roomId": "!b:host",
+						"powerLevel": 0
+					}
+				]
 			},
 			{
 				"id": "@c:host",
 				"active": true,
-				"joinedRoomIds": ["!a:host", "!b:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					},
+					{
+						"roomId": "!b:host",
+						"powerLevel": 0
+					}
+				]
 			},
 			{
 				"id": "@d:host",
 				"active": false,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -90,6 +132,21 @@
 				"payload": {
 					"userId": "@c:host",
 					"roomId": "!b:host"
+				}
+			},
+
+			{
+				"type": "room.users_set_power_levels",
+				"payload": {
+					"roomId": "!a:host",
+					"roomPowerForUserId": "map[@b:host:0 @c:host:0]"
+				}
+			},
+			{
+				"type": "room.users_set_power_levels",
+				"payload": {
+					"roomId": "!b:host",
+					"roomPowerForUserId": "map[@c:host:0]"
 				}
 			}
 		]

--- a/corporal/reconciliation/computator/testdata/04-unmanaged-rooms-are-untouched.json
+++ b/corporal/reconciliation/computator/testdata/04-unmanaged-rooms-are-untouched.json
@@ -4,7 +4,12 @@
 			{
 				"id": "@a:host",
 				"active": true,
-				"joinedRoomIds": ["!d:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!d:host",
+						"powerLevel": 0
+					}
+				]
 			}
 		]
 	},
@@ -25,7 +30,20 @@
 			{
 				"id": "@a:host",
 				"active": true,
-				"joinedRoomIds": ["!a:host", "!b:host", "!c:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					},
+					{
+						"roomId": "!b:host",
+						"powerLevel": 0
+					},
+					{
+						"roomId": "!c:host",
+						"powerLevel": 0
+					}
+				]
 			}
 		]
 	},
@@ -37,6 +55,14 @@
 				"payload": {
 					"userId": "@a:host",
 					"roomId": "!b:host"
+				}
+			},
+
+			{
+				"type": "room.users_set_power_levels",
+				"payload": {
+					"roomId": "!a:host",
+					"roomPowerForUserId": "map[@a:host:0 @b:host:0 @c:host:0]"
 				}
 			}
 		]

--- a/corporal/reconciliation/computator/testdata/05-display-names-are-enforced.json
+++ b/corporal/reconciliation/computator/testdata/05-display-names-are-enforced.json
@@ -4,18 +4,18 @@
 			{
 				"id": "@a:host",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			},
 			{
 				"id": "@b:host",
 				"displayName": "B",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			},
 			{
 				"id": "@c:host",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -33,18 +33,18 @@
 				"id": "@a:host",
 				"displayName": "User A",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			},
 			{
 				"id": "@b:host",
 				"displayName": "User B",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			},
 			{
 				"id": "@c:host",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/06-display-names-are-untouched.json
+++ b/corporal/reconciliation/computator/testdata/06-display-names-are-untouched.json
@@ -5,7 +5,7 @@
 				"id": "@a:host",
 				"displayName": "A",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -23,7 +23,7 @@
 				"id": "@a:host",
 				"displayName": "User A likes it custom",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/07-deactivated-and-missing-accounts-are-untouched.json
+++ b/corporal/reconciliation/computator/testdata/07-deactivated-and-missing-accounts-are-untouched.json
@@ -11,7 +11,7 @@
 			{
 				"id": "@a:host",
 				"active": false,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/08-deactivated-accounts-have-untouched-profiles.json
+++ b/corporal/reconciliation/computator/testdata/08-deactivated-accounts-have-untouched-profiles.json
@@ -5,7 +5,12 @@
 				"id": "@a:host",
 				"displayName": "A",
 				"active": false,
-				"joinedRoomIds": ["!a:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					}
+				]
 			}
 		]
 	},
@@ -23,7 +28,7 @@
 				"id": "@a:host",
 				"displayName": "User A",
 				"active": false,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/09-deactivated-accounts-get-deactivated.json
+++ b/corporal/reconciliation/computator/testdata/09-deactivated-accounts-get-deactivated.json
@@ -5,7 +5,7 @@
 				"id": "@a:host",
 				"displayName": "A",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -23,7 +23,7 @@
 				"id": "@a:host",
 				"displayName": "User A",
 				"active": false,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/10-deactivated-accounts-get-activated.json
+++ b/corporal/reconciliation/computator/testdata/10-deactivated-accounts-get-activated.json
@@ -5,7 +5,7 @@
 				"id": "@a:host",
 				"displayName": "A",
 				"active": false,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -23,7 +23,7 @@
 				"id": "@a:host",
 				"displayName": "User A",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/11-deactivated-accounts-leave-upon-deactivation.json
+++ b/corporal/reconciliation/computator/testdata/11-deactivated-accounts-leave-upon-deactivation.json
@@ -5,7 +5,16 @@
 				"id": "@a:host",
 				"displayName": "A",
 				"active": true,
-				"joinedRoomIds": ["!a:host", "!another:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					},
+					{
+						"roomId": "!another:host",
+						"powerLevel": 0
+					}
+				]
 			}
 		]
 	},
@@ -28,7 +37,7 @@
 				"id": "@a:host",
 				"displayName": "User A",
 				"active": false,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/12-past-deactivated-accounts-also-leave.json
+++ b/corporal/reconciliation/computator/testdata/12-past-deactivated-accounts-also-leave.json
@@ -5,7 +5,16 @@
 				"id": "@a:host",
 				"displayName": "A",
 				"active": false,
-				"joinedRoomIds": ["!a:host", "!another:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					},
+					{
+						"roomId": "!another:host",
+						"powerLevel": 0
+					}
+				]
 			}
 		]
 	},
@@ -28,7 +37,7 @@
 				"id": "@a:host",
 				"displayName": "User A",
 				"active": false,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/13-empty-display-names-are-avoided.json
+++ b/corporal/reconciliation/computator/testdata/13-empty-display-names-are-avoided.json
@@ -5,7 +5,7 @@
 				"id": "@a:host",
 				"displayName": "",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -23,7 +23,7 @@
 				"id": "@a:host",
 				"displayName": "User A",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/14-empty-avatars-are-not-set.json
+++ b/corporal/reconciliation/computator/testdata/14-empty-avatars-are-not-set.json
@@ -7,7 +7,7 @@
 				"displayName": "",
 				"avatarMxcUri": "",
 				"avatarSourceUriHash": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -26,7 +26,7 @@
 				"active": true,
 				"displayName": "",
 				"avatarUri": "",
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/15-avatars-are-set-on-hash-mismatch.json
+++ b/corporal/reconciliation/computator/testdata/15-avatars-are-set-on-hash-mismatch.json
@@ -7,7 +7,7 @@
 				"displayName": "",
 				"avatarMxcUri": "",
 				"avatarSourceUriHash": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -26,7 +26,7 @@
 				"active": true,
 				"displayName": "",
 				"avatarUri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/16-avatars-are-not-set-on-same-hash.json
+++ b/corporal/reconciliation/computator/testdata/16-avatars-are-not-set-on-same-hash.json
@@ -7,7 +7,7 @@
 				"displayName": "",
 				"avatarMxcUri": "mxc://something/another",
 				"avatarSourceUriHash": "53d18b18fddf6a58bebf9c2f349020a37e0136d2cb24de236f7ae9deeefebbd3bf67bf245825e4fb9397003e6b8c1ca5c1490a098db183fabf243e8666c3c15f",
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -26,7 +26,7 @@
 				"active": true,
 				"displayName": "",
 				"avatarUri": "http://example.com/image.jpg",
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/17-no-display-name-is-fine.json
+++ b/corporal/reconciliation/computator/testdata/17-no-display-name-is-fine.json
@@ -5,7 +5,7 @@
 				"id": "@a:host",
 				"active": true,
 				"displayName": "Something",
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},
@@ -22,7 +22,7 @@
 			{
 				"id": "@a:host",
 				"active": true,
-				"joinedRoomIds": []
+				"joinedRooms": []
 			}
 		]
 	},

--- a/corporal/reconciliation/computator/testdata/18-missing-user-with-passthrough-auth-is-created.json
+++ b/corporal/reconciliation/computator/testdata/18-missing-user-with-passthrough-auth-is-created.json
@@ -22,7 +22,12 @@
 				"authType": "passthrough",
 				"authCredential": "some-initial-password",
 				"active": true,
-				"joinedRoomIds": ["!a:host"]
+				"joinedRooms": [
+					{
+						"roomId": "!a:host",
+						"powerLevel": 0
+					}
+				]
 			}
 		]
 	},
@@ -42,6 +47,14 @@
 				"payload": {
 					"userId": "@a:host",
 					"roomId": "!a:host"
+				}
+			},
+
+			{
+				"type": "room.users_set_power_levels",
+				"payload": {
+					"roomId": "!a:host",
+					"roomPowerForUserId": "map[@a:host:0]"
 				}
 			}
 		]

--- a/corporal/reconciliation/computator/testdata/19-set-power-only-if-necessary.json
+++ b/corporal/reconciliation/computator/testdata/19-set-power-only-if-necessary.json
@@ -1,0 +1,119 @@
+{
+    "currentState": {
+        "users": [
+            {
+                "id": "@a:host",
+                "active": true,
+                "joinedRooms": [
+                    {
+                        "roomId": "!a:host",
+                        "powerLevel": 0
+                    },
+                    {
+                        "roomId": "!b:host",
+                        "powerLevel": 0
+                    }
+                ]
+            },
+            {
+                "id": "@b:host",
+                "active": true,
+                "joinedRooms": [
+                    {
+                        "roomId": "!a:host",
+                        "powerLevel": 0
+                    },
+                    {
+                        "roomId": "!c:host",
+                        "powerLevel": 0
+                    }
+                ]
+            },
+            {
+                "id": "@c:host",
+                "active": true,
+                "joinedRooms": [
+                    {
+                        "roomId": "!c:host",
+                        "powerLevel": 0
+                    }
+                ]
+            }
+        ]
+    },
+
+    "policy": {
+        "schemaVersion": 1,
+
+        "flags": {
+            "allowCustomUserDisplayNames": true,
+            "allowCustomUserAvatars": true
+        },
+
+        "managedRoomIds": [
+            "!a:host",
+            "!b:host",
+            "!c:host"
+        ],
+
+        "users": [
+            {
+                "id": "@a:host",
+                "active": true,
+                "joinedRooms": [
+                    {
+                        "roomId": "!a:host",
+                        "powerLevel": 10
+                    },
+                    {
+                        "roomId": "!b:host",
+                        "powerLevel": 0
+                    }
+                ]
+            },
+            {
+                "id": "@b:host",
+                "active": true,
+                "joinedRooms": [
+                    {
+                        "roomId": "!a:host",
+                        "powerLevel": 42
+                    },
+                    {
+                        "roomId": "!c:host",
+                        "powerLevel": 0
+                    }
+                ]
+            },
+            {
+                "id": "@c:host",
+                "active": true,
+                "joinedRooms": [
+                    {
+                        "roomId": "!c:host",
+                        "powerLevel": 60
+                    }
+                ]
+            }
+        ]
+    },
+
+    "reconciliationState": {
+        "actions": [
+            {
+                "type": "room.users_set_power_levels",
+                "payload": {
+                    "roomId": "!a:host",
+                    "roomPowerForUserId": "map[@a:host:10 @b:host:42]"
+                }
+            },
+            {
+                "type": "room.users_set_power_levels",
+                "payload": {
+                    "roomId": "!c:host",
+                    "roomPowerForUserId": "map[@c:host:60]"
+                }
+            }
+        ]
+    }
+}

--- a/corporal/reconciliation/reconciler/reconciler.go
+++ b/corporal/reconciliation/reconciler/reconciler.go
@@ -50,8 +50,9 @@ func New(
 		reconciliation.ActionUserActivate:       me.reconcileForActionUserActivate,
 		reconciliation.ActionUserDeactivate:     me.reconcileForActionUserDeactivate,
 
-		reconciliation.ActionRoomJoin:  me.reconcileForActionRoomJoin,
-		reconciliation.ActionRoomLeave: me.reconcileForActionRoomLeave,
+		reconciliation.ActionRoomJoin:          me.reconcileForActionRoomJoin,
+		reconciliation.ActionRoomLeave:         me.reconcileForActionRoomLeave,
+		reconciliation.ActionRoomSetPowerLevel: me.reconcileForActionRoomSetPower,
 	}
 
 	return me
@@ -232,7 +233,17 @@ func (me *Reconciler) reconcileForActionRoomJoin(ctx *connector.AccessTokenConte
 		return err
 	}
 
+	powerLevel, err := action.GetIntPayloadDataByKey("powerLevel")
+	if err != nil {
+		return err
+	}
+
 	err = me.connector.InviteUserToRoom(ctx, me.reconciliatorUserId, userId, roomId)
+	if err != nil {
+		return err
+	}
+
+	err = me.connector.UpdateRoomUserPowerLevel(ctx, me.reconciliatorUserId, userId, roomId, powerLevel)
 	if err != nil {
 		return err
 	}
@@ -252,4 +263,23 @@ func (me *Reconciler) reconcileForActionRoomLeave(ctx *connector.AccessTokenCont
 	}
 
 	return me.connector.LeaveRoom(ctx, userId, roomId)
+}
+
+func (me *Reconciler) reconcileForActionRoomSetPower(ctx *connector.AccessTokenContext, action *reconciliation.StateAction) error {
+	userId, err := action.GetStringPayloadDataByKey("userId")
+	if err != nil {
+		return err
+	}
+
+	roomId, err := action.GetStringPayloadDataByKey("roomId")
+	if err != nil {
+		return err
+	}
+
+	powerLevel, err := action.GetIntPayloadDataByKey("powerLevel")
+	if err != nil {
+		return err
+	}
+
+	return me.connector.UpdateRoomUserPowerLevel(ctx, me.reconciliatorUserId, userId, roomId, powerLevel)
 }

--- a/corporal/reconciliation/state.go
+++ b/corporal/reconciliation/state.go
@@ -24,6 +24,19 @@ func (me *StateAction) GetStringPayloadDataByKey(key string) (string, error) {
 	return dataCasted, nil
 }
 
+func (me *StateAction) GetIntPayloadDataByKey(key string) (int, error) {
+	data, err := me.getPayloadDataByKey(key)
+	if err != nil {
+		return 0, err
+	}
+
+	dataCasted, castOk := data.(int)
+	if !castOk {
+		return 0, fmt.Errorf("Failed casting payload data for: %s", key)
+	}
+	return dataCasted, nil
+}
+
 func (me *StateAction) getPayloadDataByKey(key string) (interface{}, error) {
 	data, exists := me.Payload[key]
 	if !exists {

--- a/corporal/reconciliation/state.go
+++ b/corporal/reconciliation/state.go
@@ -12,7 +12,7 @@ type StateAction struct {
 }
 
 func (me *StateAction) GetStringPayloadDataByKey(key string) (string, error) {
-	data, err := me.getPayloadDataByKey(key)
+	data, err := me.GetPayloadDataByKey(key)
 	if err != nil {
 		return "", err
 	}
@@ -25,7 +25,7 @@ func (me *StateAction) GetStringPayloadDataByKey(key string) (string, error) {
 }
 
 func (me *StateAction) GetIntPayloadDataByKey(key string) (int, error) {
-	data, err := me.getPayloadDataByKey(key)
+	data, err := me.GetPayloadDataByKey(key)
 	if err != nil {
 		return 0, err
 	}
@@ -37,7 +37,7 @@ func (me *StateAction) GetIntPayloadDataByKey(key string) (int, error) {
 	return dataCasted, nil
 }
 
-func (me *StateAction) getPayloadDataByKey(key string) (interface{}, error) {
+func (me *StateAction) GetPayloadDataByKey(key string) (interface{}, error) {
 	data, exists := me.Payload[key]
 	if !exists {
 		return nil, fmt.Errorf("Missing %s payload data", key)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,11 +47,11 @@ It might be possible to forward traffic selectively (just the "dangerous" or oth
 
 ## Can users join other rooms?
 
-Users are automatically joined and made to leave rooms according to the `joinedRoomIds` field in their [user policy](policy.md#user-policy-fields) and to the global `managedRoomIds` [policy field](policy.md#fields).
+Users are automatically joined and made to leave rooms according to the `joinedRooms` field in their [user policy](policy.md#user-policy-fields) and to the global `managedRoomIds` [policy field](policy.md#fields).
 
 Users can create and join any room which is not listed in the global `managedRoomIds` policy field.
 
-It's just rooms listed in the `managedRoomIds` that `matrix-corporal` cares about and controls tightly (requiring an explicit join rule in the `joinedRoomIds` list for that user).
+It's just rooms listed in the `managedRoomIds` that `matrix-corporal` cares about and controls tightly (requiring an explicit join rule in the `joinedRooms` list for that user).
 
 
 ## Does Matrix Corporal require access to Matrix Synapse's database?

--- a/docs/user-authentication.md
+++ b/docs/user-authentication.md
@@ -29,7 +29,10 @@ Here's an example policy:
 			"authCredential": "PaSSw0rD",
 			"displayName": "John",
 			"avatarUri": "https://example.com/john.jpg",
-			"joinedRoomIds": ["!roomA:example.com", "!roomB:example.com"]
+			"joinedRooms": [
+				{"roomId": "!roomA:example.com", "powerLevel": 0},
+				{"roomId": "!roomB:example.com", "powerLevel": 50}
+			]
 		}
 	]
 }
@@ -64,7 +67,10 @@ Here's an example policy:
 			"authCredential": "some-initial-password",
 			"displayName": "John",
 			"avatarUri": "https://example.com/john.jpg",
-			"joinedRoomIds": ["!roomA:example.com", "!roomB:example.com"]
+			"joinedRooms": [
+				{"roomId": "!roomA:example.com", "powerLevel": 0},
+				{"roomId": "!roomB:example.com", "powerLevel": 50}
+			]
 		}
 	]
 }
@@ -89,7 +95,10 @@ Here's an example policy:
 			"authCredential": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
 			"displayName": "Just Peter",
 			"avatarUri": "",
-			"joinedRoomIds": ["!roomB:example.com"]
+			"joinedRooms": [
+				{"roomId": "!roomA:example.com", "powerLevel": 0},
+				{"roomId": "!roomB:example.com", "powerLevel": 50}
+			]
 		}
 	]
 }
@@ -118,7 +127,10 @@ Here's an example policy:
 			"authCredential": "https://intranet.example.com/_matrix-internal/identity/v1/check_credentials",
 			"displayName": "Georgey",
 			"avatarUri": "",
-			"joinedRoomIds": ["!roomA:example.com", "!roomB:example.com"]
+			"joinedRooms": [
+				{"roomId": "!roomA:example.com", "powerLevel": 0},
+				{"roomId": "!roomB:example.com", "powerLevel": 50}
+			]
 		}
 	]
 }

--- a/policy.json.dist
+++ b/policy.json.dist
@@ -39,7 +39,7 @@
 			"authType": "plain",
 			"authCredential": "test",
 			"displayName": "User A",
-			"joinedRoomIds": [],
+			"joinedRooms": [],
 			"forbidRoomCreation": false,
 			"forbidEncryptedRoomCreation": true
 		},
@@ -50,7 +50,7 @@
 			"authCredential": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
 			"displayName": "User B",
 			"avatarUri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
-			"joinedRoomIds": [],
+			"joinedRooms": [],
 			"forbidRoomCreation": true
 		},
 		{
@@ -59,7 +59,7 @@
 			"authType": "rest",
 			"authCredential": "http://rest-password-auth-service:8080/_matrix-internal/identity/v1/check_credentials",
 			"displayName": "User C",
-			"joinedRoomIds": [],
+			"joinedRooms": [],
 			"forbidRoomCreation": false,
 			"forbidUnencryptedRoomCreation": true
 		}


### PR DESCRIPTION
## Object
Allows setting a power level for each user's room in the policy.

## Context
We are using Matrix Corporal for a project, and we lacked the ability to manage users' power levels.

## Changes
- `joinedRoomIds` in the policy has been renamed to `joinedRooms` and now consists of a list of objects including `roomId` and `powerLevel`.
- Added functions to handle the power levels of each user in each room. The computator now compares the expected power level with the current power level for a user and a room. An action is added to the actions list only if the power levels differ.
- There are 2 new action types: "room.user_set_power_level" and "room.users_set_power_levels".
   - The "room.user_set_power_level" action describes one user's room's power level change. The payload includes `userId`, `roomId` and `powerLevel`.
   - The "room.users_set_power_levels" action describes a group of power levels to change for users in a single room. The payload includes `roomId` and `roomPowerForUserId` which is a map of userId->powerLevel. We needed this second action type to group all power level requests for the same rooms. This allows us to execute a single request per room with power level changes instead of one for each user. If 50 users are changing their power levels in 10 different rooms, we only send 10 power level requests instead of 500.
- Fixed existing tests and added a computator test file.

> :warning: We did not implement some input checks for `powerLevel` in the policy. This also means that if a user gets a higher power level in a room than the matrix admin, the room's state won't be able to be changed.